### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "networksecurity",
     "name_pretty": "Network Security API",
     "product_documentation": "https://cloud.google.com/traffic-director/docs/reference/network-security/rest",
-    "client_documentation": "https://googleapis.dev/python/networksecurity/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/networksecurity/latest",
     "issue_tracker": "",
     "release_level": "beta",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for Network Security API
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-network-security.svg
    :target: https://pypi.org/project/google-cloud-network-security/
 .. _Network Security API: https://cloud.google.com/traffic-director/docs/reference/network-security/rest
-.. _Client Library Documentation: https://googleapis.dev/python/networksecurity/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/networksecurity/latest
 .. _Product Documentation:  https://cloud.google.com/traffic-director/docs/reference/network-security/rest
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.