### PR TITLE
chore: use default owlbot.py file

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -35,7 +35,7 @@ for library in s.get_staging_dirs(default_version):
     if clean_up_generated_samples:
         shutil.rmtree("samples/generated_samples", ignore_errors=True)
         clean_up_generated_samples = False
-    s.move([library], excludes=["**/gapic_version.py", "setup.py", "testing/constraints-3.7.txt"])
+    s.move([library], excludes=["**/gapic_version.py"])
 s.remove_staging_dirs()
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
I ran the following commands locally and there were no changes to the generated code.

In a clone of googleapis/googleapis, run these commands to generate the clients

```
 bazel build //google/cloud/networksecurity/v1:networksecurity-v1-py
 bazel build //google/cloud/networksecurity/v1beta1:networksecurity-v1beta1-py
```

In a clone of this repo, run these commands to copy the generated client and run the post processor
```
docker run --rm --user $(id -u):$(id -g)   -v $(pwd):/repo   -v $HOME/git/googleapis/bazel-bin:/bazel-bin   gcr.io/cloud-devrel-public-resources/owlbot-cli:latest copy-bazel-bin   --source-dir /bazel-bin --dest /repo
```

```
docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo gcr.io/cloud-devrel-public-resources/owlbot-python:latest
```